### PR TITLE
Creates a certificate for HAProxy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -61,3 +61,26 @@ ${module.potstill_certificate.certificate}
 CHAIN
   filename = "${local.directories.secrets}/potstill.${local.subdomain}.crt"
 }
+
+module "haproxy_certificate" {
+  source = "github.com/shortrib-net/terraform-module-certificate"
+
+  host  = "haproxy.${local.subdomain}"
+  email = var.email
+   
+  gcp_service_account = module.dns_challenge_service_account.private_key
+}
+
+resource "local_file" "haproxy_certificate" {
+  content = <<CHAIN
+${module.haproxy_certificate.certificate}
+CHAIN
+  filename = "${local.directories.secrets}/haproxy.${local.subdomain}.crt"
+}
+
+resource "local_file" "haproxy_private_key" {
+  content = <<CHAIN
+${module.haproxy_certificate.private_key}
+CHAIN
+  filename = "${local.directories.secrets}/haproxy.${local.subdomain}.key"
+}


### PR DESCRIPTION
TL;DR
-----

Prepares for K8s install by generating a certificate for HAProxy

Details
-------

vSphere with Tanzu requires an HAProxy instance when not using NSX.
The HAProxy appliance that's recommended requires a TLS cert as
part of installing the OVA. This update creates a certificate for
the HAProxy instance.

I'm still not 100% on why the certificate is needed since HAProxy
will balance request for Kubernetes Ingress endpoints that are
providing their own certificates. Nevertheless I'm making sure
that I have a legit cetificate as part of the installation.