### PR TITLE
Switches the default lab subdomain

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -2,8 +2,8 @@ export PROJECT_DIR=${PWD}
 PATH=${PROJECT_DIR}/bin:${PATH}
 SECRETS_DIR=${PROJECT_DIR}/secrets
 
-export TF_VAR_domain=crdant.net
+export TF_VAR_domain=shortrib.net
 export TF_VAR_email=cdantonio@vmware.com
 export TF_VAR_project_root=${PROJECT_DIR}
 export TF_VAR_environment=lab
-export TF_VAR_gcp_project=crdant-net
+export TF_VAR_gcp_project=shortrib

--- a/providers.tf
+++ b/providers.tf
@@ -1,5 +1,5 @@
 provider "google" {
   credentials = file("${local.directories.secrets}/gcp-homelab-service-account.json")
-  project     = "crdant-net"
+  project     = "${var.gcp_project}"
   region      = "us-east-4"
 }

--- a/providers.tf
+++ b/providers.tf
@@ -1,5 +1,5 @@
 provider "google" {
   credentials = file("${local.directories.secrets}/gcp-homelab-service-account.json")
-  project     = "${var.gcp_project}"
+  project     = var.gcp_project
   region      = "us-east-4"
 }


### PR DESCRIPTION
TL;DR
-----

Uses the new more artful whimsical subdomain `shortrib.net` as 
a default

Details
-------

Updates the default values for the Terraform variables (set with 
`direnv`) so the certificates will be created for hosts in the 
`shortrib.net` domain and the DNS challenge will use the right
project in GCP to set DNS entries.
